### PR TITLE
Remove cleartextTrafficPermitted attribute

### DIFF
--- a/_posts/2025-04-21-crystal-clear-certs.md
+++ b/_posts/2025-04-21-crystal-clear-certs.md
@@ -67,7 +67,7 @@ While this overview glosses over a lot of finer details, Matt Dolanâ€™s talk [â€
 
 So, with a lot of preamble out of the way, what has *actually* changed as of Android 16 (API 36)?
 
-The [Network Security Config file](https://developer.android.com/privacy-and-security/security-config#FileFormat) now contains a`certificateTransparency` tag allowing CT to be enabled *globally* or *per domain* for Android 16+ devices.
+The [Network Security Config file](https://developer.android.com/privacy-and-security/security-config#FileFormat) now contains a `certificateTransparency` tag allowing CT to be enabled *globally* or *per domain* for Android 16+ devices.
 
 Adding this to your existing security configuration is super straightforward and can be done with just a couple of additional lines.
 
@@ -88,7 +88,7 @@ Adding this to your existing security configuration is super straightforward and
 ```
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-  <base-config cleartextTrafficPermitted="false">
+  <base-config>
     <certificateTransparency enabled="true"/>
   </base-config>
 </network-security-config>


### PR DESCRIPTION
Hi there! Thanks for writing this blog post about Android's new Certificate Transparency feature.  Since Android 9 (API level 28), `cleartextTrafficPermitted` is disabled by default, so there is no need to specify this attribute in the example. I thought I'd send a pull request as a suggestion.

While there, I noticed a small typo ("now contains a`certificateTransparency`", missing a space)

Also, on your comment "[...] it is worth noting that enabling this feature may interfere with your setup if you are currently allowing user or custom certificates. Given that those certificates may not be public, certificate transparency will not work.", the [behaviour is currently to disable](https://developer.android.com/privacy-and-security/security-config#certificateTransparency) certificate transparency if the app specifies its own certificates (see the `<trust-anchors>` part in the description).

Thanks!